### PR TITLE
Add GitHub Actions, split LICENSE into LICENSE and NOTICE, update doc…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy, rustfmt
+
+    - name: Setup Git for tests
+      run: |
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "actions@github.com"
+
+    - name: Format check
+      run: make format
+
+    - name: Lint
+      run: make lint
+
+    - name: Check
+      run: make check
+
+    - name: Build
+      run: make build
+
+    - name: Test
+      run: make test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Setup Git for tests
+      run: |
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "actions@github.com"
+
+    - name: Run tests
+      run: make test
+
+    - name: Publish to crates.io
+      run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrale-acdm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Wrale Agnostic Content Dependency Manager"
 authors = ["Wrale LTD <contact@wrale.com>"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,4 @@
 MIT License
-wrale-acdm - Wrale Agnostic Content Dependency Manager
-Copyright (c) 2025 Wrale LTD <contact@wrale.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+wrale-acdm - Wrale Agnostic Content Dependency Manager
+Copyright (c) 2025 Wrale LTD <contact@wrale.com>

--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ Wrale Agnostic Content Dependency Manager
 
 ## Installation
 
+> ⚠️ **Platform Support**: Currently, `wrale-acdm` is only officially supported on macOS (specifically tested on M1 MacBook Air). While it may work on other platforms when built from source, these are not officially supported yet. Contributions for other platforms are welcome!
+
 ```bash
-# Not yet available on crates.io
-cargo install --git https://github.com/wrale/wrale-acdm.git
+# Install from crates.io
+cargo install wrale-acdm
 ```
 
-or
+or install from source:
 
 ```bash
 git clone https://github.com/wrale/wrale-acdm.git
@@ -109,6 +111,7 @@ target = "vendor/example"
 Requirements:
 - Rust 1.70+
 - Git 2.25+ (for sparse checkout features)
+- macOS for primary development and testing
 
 Building from source:
 
@@ -140,7 +143,7 @@ make help
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the MIT License - see the LICENSE file for details. Copyright information is available in the NOTICE file.
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -6,6 +6,15 @@
 
 - Rust 1.70 or higher
 - Git 2.25 or higher (for sparse checkout features)
+- macOS operating system (currently only officially supported on macOS, specifically M1 MacBook Air)
+
+### Installation from crates.io
+
+Once published, you can install directly from crates.io:
+
+```bash
+cargo install wrale-acdm
+```
 
 ### Installation from Source
 
@@ -30,6 +39,12 @@
    ```bash
    acdm --version
    ```
+
+## Platform Support
+
+Currently, `wrale-acdm` is only officially supported on macOS. While it may work on other platforms when built from source, these are not officially supported yet. The tool has been primarily tested on M1 MacBook Air.
+
+If you're interested in helping maintain support for other platforms, contributions are welcome!
 
 ## Usage Guide
 
@@ -219,6 +234,10 @@ Note: Unlike previous versions, `acdm` will not automatically stage or commit an
    - Check if the target directory exists and has correct permissions
    - Verify that the source repository is accessible
    - Run with verbose logging to see detailed error information
+
+6. **Platform-Specific Issues**:
+   - If you're using a platform other than macOS, be aware that this is experimental
+   - Report any platform-specific issues on GitHub
 
 ---
 


### PR DESCRIPTION
…s for macOS support

- Add CI and publish workflows using GitHub Actions
- Split LICENSE file into LICENSE and NOTICE for better compliance
- Update README and user guide to clarify macOS support status
- Update installation instructions for crates.io publishing